### PR TITLE
HU09-VerPedidos

### DIFF
--- a/RusarfiServer/Controllers/OrdersController.cs
+++ b/RusarfiServer/Controllers/OrdersController.cs
@@ -23,9 +23,27 @@ public sealed class OrdersController(IOrderService orderService) : ControllerBas
     }
 
     [HttpGet("user/{userId:int}")]
-    public async Task<IActionResult> GetOrdersByUser(int userId, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetOrdersByUser(
+        int userId,
+        [FromQuery] string? status,
+        [FromQuery] DateTime? fromDate,
+        [FromQuery] DateTime? toDate,
+        CancellationToken cancellationToken)
     {
-        var result = await orderService.GetOrdersByUserAsync(userId, cancellationToken);
+        var result = await orderService.GetOrdersByUserAsync(userId, status, fromDate, toDate, cancellationToken);
+
+        if (!result.Success)
+        {
+            return StatusCode(result.StatusCode, ApiResponse<object>.Fail(result.Message));
+        }
+
+        return StatusCode(result.StatusCode, ApiResponse<object>.Ok(result.Message, result.Data));
+    }
+
+    [HttpGet("user/{userId:int}/{orderId:int}")]
+    public async Task<IActionResult> GetOrderById(int userId, int orderId, CancellationToken cancellationToken)
+    {
+        var result = await orderService.GetOrderByIdAsync(userId, orderId, cancellationToken);
 
         if (!result.Success)
         {

--- a/RusarfiServer/Service/IOrderService.cs
+++ b/RusarfiServer/Service/IOrderService.cs
@@ -5,5 +5,16 @@ namespace RusarfiServer.Service;
 public interface IOrderService
 {
     Task<ServiceResult<ConfirmOrderResponse>> ConfirmOrderAsync(ConfirmOrderRequest request, CancellationToken cancellationToken);
-    Task<ServiceResult<List<OrderDto>>> GetOrdersByUserAsync(int userId, CancellationToken cancellationToken);
+
+    Task<ServiceResult<List<OrderDto>>> GetOrdersByUserAsync(
+        int userId,
+        string? status,
+        DateTime? fromDate,
+        DateTime? toDate,
+        CancellationToken cancellationToken);
+
+    Task<ServiceResult<OrderDto>> GetOrderByIdAsync(
+        int userId,
+        int orderId,
+        CancellationToken cancellationToken);
 }

--- a/RusarfiServer/Service/OrderService.cs
+++ b/RusarfiServer/Service/OrderService.cs
@@ -112,7 +112,12 @@ public sealed class OrderService(AppDbContext db) : IOrderService
         }
     }
 
-    public async Task<ServiceResult<List<OrderDto>>> GetOrdersByUserAsync(int userId, CancellationToken cancellationToken)
+    public async Task<ServiceResult<List<OrderDto>>> GetOrdersByUserAsync(
+    int userId,
+    string? status,
+    DateTime? fromDate,
+    DateTime? toDate,
+    CancellationToken cancellationToken)
     {
         if (userId <= 0)
         {
@@ -125,9 +130,27 @@ public sealed class OrderService(AppDbContext db) : IOrderService
             return ServiceResult<List<OrderDto>>.Fail("El usuario no existe", 404);
         }
 
-        var orders = await db.Orders
+        var query = db.Orders
             .AsNoTracking()
-            .Where(o => o.UserId == userId)
+            .Where(o => o.UserId == userId);
+
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            var normalizedStatus = status.Trim().ToLower();
+            query = query.Where(o => o.Status.ToLower().Contains(normalizedStatus));
+        }
+
+        if (fromDate.HasValue)
+        {
+            query = query.Where(o => o.CreatedAtUtc.Date >= fromDate.Value.Date);
+        }
+
+        if (toDate.HasValue)
+        {
+            query = query.Where(o => o.CreatedAtUtc.Date <= toDate.Value.Date);
+        }
+
+        var orders = await query
             .OrderByDescending(o => o.CreatedAtUtc)
             .Select(o => new OrderDto
             {
@@ -157,5 +180,50 @@ public sealed class OrderService(AppDbContext db) : IOrderService
         }
 
         return ServiceResult<List<OrderDto>>.Ok("Pedidos obtenidos correctamente", orders, 200);
+    }
+
+    public async Task<ServiceResult<OrderDto>> GetOrderByIdAsync(int userId, int orderId, CancellationToken cancellationToken)
+    {
+        if (userId <= 0)
+        {
+            return ServiceResult<OrderDto>.Fail("El usuario es obligatorio", 400);
+        }
+
+        if (orderId <= 0)
+        {
+            return ServiceResult<OrderDto>.Fail("El pedido es obligatorio", 400);
+        }
+
+        var order = await db.Orders
+            .AsNoTracking()
+            .Where(o => o.UserId == userId && o.Id == orderId)
+            .Select(o => new OrderDto
+            {
+                OrderId = o.Id,
+                UserId = o.UserId,
+                Total = o.Total,
+                Status = o.Status,
+                CreatedAtUtc = o.CreatedAtUtc,
+                Items = o.Items
+                    .OrderBy(i => i.ProductName)
+                    .Select(i => new OrderItemDto
+                    {
+                        ProductId = i.ProductId,
+                        ProductName = i.ProductName,
+                        ImageUrl = i.ImageUrl,
+                        Quantity = i.Quantity,
+                        UnitPrice = i.UnitPrice,
+                        Subtotal = i.Subtotal
+                    })
+                    .ToList()
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (order is null)
+        {
+            return ServiceResult<OrderDto>.Fail("Pedido no encontrado", 404);
+        }
+
+        return ServiceResult<OrderDto>.Ok("Pedido obtenido correctamente", order, 200);
     }
 }


### PR DESCRIPTION
Se implementa la visualización del historial de pedidos del usuario.

Incluye:

Listado de pedidos realizados por el usuario
Visualización de número de pedido, fecha, total y estado
Consulta de detalle de cada pedido (productos, cantidades, precios)
Mensaje claro cuando no existen pedidos: “No tienes pedidos en tu historial”
Filtro de pedidos por estado y rango de fechas
Orden descendente por fecha (más recientes primero)

Endpoints probados en Postman.